### PR TITLE
質問内容登録画面のUIを作成

### DIFF
--- a/QuestionApp.xcodeproj/project.pbxproj
+++ b/QuestionApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4CD42DD5ABF620D508BB08AA /* Pods_QuestionApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F42C41B5328264FBA34588C0 /* Pods_QuestionApp.framework */; };
 		E30FEB3825064FCB00B2F45B /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30FEB3725064FCB00B2F45B /* HomeViewController.swift */; };
+		E30FEB4A250F386100B2F45B /* RegisterQuestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30FEB49250F386100B2F45B /* RegisterQuestionsViewController.swift */; };
 		E3396A3324F8E3140020AF8E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A3224F8E3140020AF8E /* AppDelegate.swift */; };
 		E3396A3524F8E3140020AF8E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A3424F8E3140020AF8E /* SceneDelegate.swift */; };
 		E3396A3724F8E3140020AF8E /* SignUpWaysViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A3624F8E3140020AF8E /* SignUpWaysViewController.swift */; };
@@ -21,6 +22,7 @@
 		19B4ADD2F3C978B35DDFE576 /* Pods-QuestionApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuestionApp.debug.xcconfig"; path = "Target Support Files/Pods-QuestionApp/Pods-QuestionApp.debug.xcconfig"; sourceTree = "<group>"; };
 		5D9B485068FDF2A63CDB69AB /* Pods-QuestionApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuestionApp.release.xcconfig"; path = "Target Support Files/Pods-QuestionApp/Pods-QuestionApp.release.xcconfig"; sourceTree = "<group>"; };
 		E30FEB3725064FCB00B2F45B /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		E30FEB49250F386100B2F45B /* RegisterQuestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterQuestionsViewController.swift; sourceTree = "<group>"; };
 		E3396A2F24F8E3140020AF8E /* QuestionApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuestionApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3396A3224F8E3140020AF8E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E3396A3424F8E3140020AF8E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -68,6 +70,7 @@
 				E3396A3424F8E3140020AF8E /* SceneDelegate.swift */,
 				E3396A3624F8E3140020AF8E /* SignUpWaysViewController.swift */,
 				E30FEB3725064FCB00B2F45B /* HomeViewController.swift */,
+				E30FEB49250F386100B2F45B /* RegisterQuestionsViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -218,6 +221,7 @@
 				E3396A3724F8E3140020AF8E /* SignUpWaysViewController.swift in Sources */,
 				E3396A3324F8E3140020AF8E /* AppDelegate.swift in Sources */,
 				E3396A3524F8E3140020AF8E /* SceneDelegate.swift in Sources */,
+				E30FEB4A250F386100B2F45B /* RegisterQuestionsViewController.swift in Sources */,
 				E30FEB3825064FCB00B2F45B /* HomeViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/QuestionApp.xcodeproj/project.pbxproj
+++ b/QuestionApp.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		E30FEB4A250F386100B2F45B /* RegisterQuestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30FEB49250F386100B2F45B /* RegisterQuestionsViewController.swift */; };
 		E30FEB4D250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30FEB4B250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift */; };
 		E30FEB4E250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E30FEB4C250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib */; };
+		E30FEB51250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30FEB4F250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.swift */; };
+		E30FEB52250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E30FEB50250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.xib */; };
 		E3396A3324F8E3140020AF8E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A3224F8E3140020AF8E /* AppDelegate.swift */; };
 		E3396A3524F8E3140020AF8E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A3424F8E3140020AF8E /* SceneDelegate.swift */; };
 		E3396A3724F8E3140020AF8E /* SignUpWaysViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A3624F8E3140020AF8E /* SignUpWaysViewController.swift */; };
@@ -27,6 +29,8 @@
 		E30FEB49250F386100B2F45B /* RegisterQuestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterQuestionsViewController.swift; sourceTree = "<group>"; };
 		E30FEB4B250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelAndTextViewTableViewCell.swift; sourceTree = "<group>"; };
 		E30FEB4C250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LabelAndTextViewTableViewCell.xib; sourceTree = "<group>"; };
+		E30FEB4F250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelAndDatePickerTableViewCell.swift; sourceTree = "<group>"; };
+		E30FEB50250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LabelAndDatePickerTableViewCell.xib; sourceTree = "<group>"; };
 		E3396A2F24F8E3140020AF8E /* QuestionApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuestionApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3396A3224F8E3140020AF8E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E3396A3424F8E3140020AF8E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -123,6 +127,8 @@
 				E3396A4024F8E31A0020AF8E /* Info.plist */,
 				E30FEB4B250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift */,
 				E30FEB4C250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib */,
+				E30FEB4F250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.swift */,
+				E30FEB50250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.xib */,
 			);
 			path = QuestionApp;
 			sourceTree = "<group>";
@@ -186,6 +192,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E30FEB52250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.xib in Resources */,
 				E30FEB4E250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib in Resources */,
 				E3396A3F24F8E31A0020AF8E /* LaunchScreen.storyboard in Resources */,
 				E3396A3C24F8E31A0020AF8E /* Assets.xcassets in Resources */,
@@ -230,6 +237,7 @@
 				E30FEB4D250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift in Sources */,
 				E3396A3524F8E3140020AF8E /* SceneDelegate.swift in Sources */,
 				E30FEB4A250F386100B2F45B /* RegisterQuestionsViewController.swift in Sources */,
+				E30FEB51250F3CB700B2F45B /* LabelAndDatePickerTableViewCell.swift in Sources */,
 				E30FEB3825064FCB00B2F45B /* HomeViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/QuestionApp.xcodeproj/project.pbxproj
+++ b/QuestionApp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		4CD42DD5ABF620D508BB08AA /* Pods_QuestionApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F42C41B5328264FBA34588C0 /* Pods_QuestionApp.framework */; };
 		E30FEB3825064FCB00B2F45B /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30FEB3725064FCB00B2F45B /* HomeViewController.swift */; };
 		E30FEB4A250F386100B2F45B /* RegisterQuestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30FEB49250F386100B2F45B /* RegisterQuestionsViewController.swift */; };
+		E30FEB4D250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30FEB4B250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift */; };
+		E30FEB4E250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E30FEB4C250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib */; };
 		E3396A3324F8E3140020AF8E /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A3224F8E3140020AF8E /* AppDelegate.swift */; };
 		E3396A3524F8E3140020AF8E /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A3424F8E3140020AF8E /* SceneDelegate.swift */; };
 		E3396A3724F8E3140020AF8E /* SignUpWaysViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3396A3624F8E3140020AF8E /* SignUpWaysViewController.swift */; };
@@ -23,6 +25,8 @@
 		5D9B485068FDF2A63CDB69AB /* Pods-QuestionApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuestionApp.release.xcconfig"; path = "Target Support Files/Pods-QuestionApp/Pods-QuestionApp.release.xcconfig"; sourceTree = "<group>"; };
 		E30FEB3725064FCB00B2F45B /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		E30FEB49250F386100B2F45B /* RegisterQuestionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterQuestionsViewController.swift; sourceTree = "<group>"; };
+		E30FEB4B250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelAndTextViewTableViewCell.swift; sourceTree = "<group>"; };
+		E30FEB4C250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LabelAndTextViewTableViewCell.xib; sourceTree = "<group>"; };
 		E3396A2F24F8E3140020AF8E /* QuestionApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuestionApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3396A3224F8E3140020AF8E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E3396A3424F8E3140020AF8E /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -117,6 +121,8 @@
 				E30EE1AB24FF5214002FE2A1 /* View */,
 				E30EE1AA24FF5204002FE2A1 /* Controller */,
 				E3396A4024F8E31A0020AF8E /* Info.plist */,
+				E30FEB4B250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift */,
+				E30FEB4C250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib */,
 			);
 			path = QuestionApp;
 			sourceTree = "<group>";
@@ -180,6 +186,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E30FEB4E250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.xib in Resources */,
 				E3396A3F24F8E31A0020AF8E /* LaunchScreen.storyboard in Resources */,
 				E3396A3C24F8E31A0020AF8E /* Assets.xcassets in Resources */,
 				E3396A3A24F8E3140020AF8E /* Main.storyboard in Resources */,
@@ -220,6 +227,7 @@
 			files = (
 				E3396A3724F8E3140020AF8E /* SignUpWaysViewController.swift in Sources */,
 				E3396A3324F8E3140020AF8E /* AppDelegate.swift in Sources */,
+				E30FEB4D250F3ACC00B2F45B /* LabelAndTextViewTableViewCell.swift in Sources */,
 				E3396A3524F8E3140020AF8E /* SceneDelegate.swift in Sources */,
 				E30FEB4A250F386100B2F45B /* RegisterQuestionsViewController.swift in Sources */,
 				E30FEB3825064FCB00B2F45B /* HomeViewController.swift in Sources */,

--- a/QuestionApp/Controller/RegisterQuestionsViewController.swift
+++ b/QuestionApp/Controller/RegisterQuestionsViewController.swift
@@ -8,9 +8,41 @@
 
 import UIKit
 
-class RegisterQuestionsViewController: UIViewController {
-
+class RegisterQuestionsViewController: UIViewController, UITableViewDataSource {
+    
+    @IBOutlet weak var tableView: UITableView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        tableView.dataSource = self
+        let questionTextViewNib = UINib(nibName: "LabelAndTextViewTableViewCell", bundle: nil)
+        let datePickerNib = UINib(nibName: "LabelAndDatePickerTableViewCell", bundle: nil)
+        tableView.register(questionTextViewNib, forCellReuseIdentifier: "LabelAndTextViewCell")
+        tableView.register(datePickerNib, forCellReuseIdentifier: "LabelAndDatePickerCell")
+        //このブランチをマージした後にカスタムセルのCategoryLabelAndTFTableviewCellとCommonActionButtonTableViewCellを追加
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 5 //マジックナンバーは使わないようあとで修正
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let questionTextViewCell = tableView.dequeueReusableCell(withIdentifier: "LabelAndTextViewCell", for: indexPath) as! LabelAndTextViewTableViewCell
+        let datePickerCell = tableView.dequeueReusableCell(withIdentifier: "LabelAndDatePickerCell", for: indexPath)
+        
+        switch indexPath.row {
+        case 0:
+            return questionTextViewCell //後からCategoryCellに修正(Label&TF)
+        case 1:
+            return questionTextViewCell
+        case 3:
+            return datePickerCell
+        case 4:
+            return questionTextViewCell //後からCategoryCellに修正(Label&TF)
+        case 5:
+            return UITableViewCell() //後からCommonActionButtonCellに修正(Button)
+        default: break
+        }
+        return UITableViewCell()
     }
 }

--- a/QuestionApp/Controller/RegisterQuestionsViewController.swift
+++ b/QuestionApp/Controller/RegisterQuestionsViewController.swift
@@ -8,9 +8,15 @@
 
 import UIKit
 
-class RegisterQuestionsViewController: UIViewController, UITableViewDataSource {
+class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, UINavigationBarDelegate {
     
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var navigationBar: UINavigationBar!
+    
+    //UINavigationBarをステータスバーまで広げる
+    func position(for bar: UIBarPositioning) -> UIBarPosition {
+        return .topAttached
+    }
     
     enum QuestionList: String, CaseIterable{
         case person = "質問する相手"
@@ -31,6 +37,7 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource {
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.dataSource = self
+        navigationBar.delegate = self
         let questionTextViewNib = UINib(nibName: "LabelAndTextViewTableViewCell", bundle: nil)
         let datePickerNib = UINib(nibName: "LabelAndDatePickerTableViewCell", bundle: nil)
         tableView.register(questionTextViewNib, forCellReuseIdentifier: "LabelAndTextViewCell")

--- a/QuestionApp/Controller/RegisterQuestionsViewController.swift
+++ b/QuestionApp/Controller/RegisterQuestionsViewController.swift
@@ -1,0 +1,16 @@
+//
+//  RegisterQuestionsViewController.swift
+//  QuestionApp
+//
+//  Created by AYANO HARA on 2020/09/14.
+//  Copyright © 2020 AYANO HARA. All rights reserved.
+//
+
+import UIKit
+
+class RegisterQuestionsViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/QuestionApp/Controller/RegisterQuestionsViewController.swift
+++ b/QuestionApp/Controller/RegisterQuestionsViewController.swift
@@ -12,6 +12,22 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource {
     
     @IBOutlet weak var tableView: UITableView!
     
+    enum QuestionList: String, CaseIterable{
+        case person = "質問する相手"
+        case question = "質問内容"
+        case date = "会う予定の日"
+        case nextAction = "次のアクション"
+        
+        var QuestionPlaceHolderList: String {
+            switch self {
+            case .person: return "例)田中 太郎"
+            case .question: return "例)食事制限をしないダイエット方法"
+            case .date: return "例)2021/01/01"
+            case .nextAction: return "例)教えてもらったダイエット方法を１ヶ月続ける"
+            }
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.dataSource = self
@@ -28,18 +44,24 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let questionTextViewCell = tableView.dequeueReusableCell(withIdentifier: "LabelAndTextViewCell", for: indexPath) as! LabelAndTextViewTableViewCell
-        let datePickerCell = tableView.dequeueReusableCell(withIdentifier: "LabelAndDatePickerCell", for: indexPath)
+        let datePickerCell = tableView.dequeueReusableCell(withIdentifier: "LabelAndDatePickerCell", for: indexPath) as! LabelAndDatePickerTableViewCell
         
         switch indexPath.row {
         case 0:
+            questionTextViewCell.categoryLabel.text = QuestionList.person.rawValue
+            //placeholder
             return questionTextViewCell //後からCategoryCellに修正(Label&TF)
         case 1:
+            questionTextViewCell.categoryLabel.text = QuestionList.question.rawValue
             return questionTextViewCell
-        case 3:
+        case 2:
+            datePickerCell.categoryLabel.text = QuestionList.date.rawValue
             return datePickerCell
-        case 4:
+        case 3:
+            questionTextViewCell.categoryLabel.text = QuestionList.nextAction.rawValue
+            //placeHolder
             return questionTextViewCell //後からCategoryCellに修正(Label&TF)
-        case 5:
+        case 4:
             return UITableViewCell() //後からCommonActionButtonCellに修正(Button)
         default: break
         }

--- a/QuestionApp/LabelAndDatePickerTableViewCell.swift
+++ b/QuestionApp/LabelAndDatePickerTableViewCell.swift
@@ -1,0 +1,24 @@
+//
+//  LabelAndDatePickerTableViewCell.swift
+//  QuestionApp
+//
+//  Created by AYANO HARA on 2020/09/14.
+//  Copyright © 2020 AYANO HARA. All rights reserved.
+//
+
+import UIKit
+
+class LabelAndDatePickerTableViewCell: UITableViewCell {
+    
+    @IBOutlet weak var categoryLabel: UILabel!
+    @IBOutlet weak var datePicker: UIDatePicker!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.selectionStyle = .none
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+}

--- a/QuestionApp/LabelAndDatePickerTableViewCell.xib
+++ b/QuestionApp/LabelAndDatePickerTableViewCell.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="167" id="KGk-i7-Jjw" customClass="LabelAndDatePickerTableViewCell" customModule="QuestionApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="422" height="167"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="422" height="167"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e1p-fT-Evd">
+                        <rect key="frame" x="20" y="11" width="313" height="36"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <datePicker contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="DeJ-zZ-fUs">
+                        <rect key="frame" x="20" y="55" width="353" height="102"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                    </datePicker>
+                </subviews>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="categoryLabel" destination="e1p-fT-Evd" id="3ZG-tk-CuA"/>
+                <outlet property="datePicker" destination="DeJ-zZ-fUs" id="ygZ-TO-h0E"/>
+            </connections>
+            <point key="canvasLocation" x="211.59420289855075" y="181.80803571428569"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/QuestionApp/LabelAndDatePickerTableViewCell.xib
+++ b/QuestionApp/LabelAndDatePickerTableViewCell.xib
@@ -9,32 +9,38 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="167" id="KGk-i7-Jjw" customClass="LabelAndDatePickerTableViewCell" customModule="QuestionApp" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="422" height="167"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="213" id="KGk-i7-Jjw" customClass="LabelAndDatePickerTableViewCell" customModule="QuestionApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="491" height="213"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="422" height="167"/>
+                <rect key="frame" x="0.0" y="0.0" width="491" height="213"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e1p-fT-Evd">
-                        <rect key="frame" x="20" y="11" width="313" height="36"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e1p-fT-Evd">
+                        <rect key="frame" x="8" y="8" width="42" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <datePicker contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="DeJ-zZ-fUs">
-                        <rect key="frame" x="20" y="55" width="353" height="102"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                    <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="DeJ-zZ-fUs">
+                        <rect key="frame" x="8" y="21" width="475" height="180"/>
                     </datePicker>
                 </subviews>
+                <constraints>
+                    <constraint firstItem="e1p-fT-Evd" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="K1F-GR-HMs"/>
+                    <constraint firstAttribute="trailing" secondItem="DeJ-zZ-fUs" secondAttribute="trailing" constant="8" id="O5e-zl-0V6"/>
+                    <constraint firstItem="DeJ-zZ-fUs" firstAttribute="top" secondItem="e1p-fT-Evd" secondAttribute="bottom" constant="-8" id="Xlo-Xz-Kyh"/>
+                    <constraint firstAttribute="bottom" secondItem="DeJ-zZ-fUs" secondAttribute="bottom" constant="12" id="gqi-qV-Qtc"/>
+                    <constraint firstItem="e1p-fT-Evd" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="jP9-6G-cDa"/>
+                    <constraint firstItem="DeJ-zZ-fUs" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="uD2-m6-HIs"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="categoryLabel" destination="e1p-fT-Evd" id="3ZG-tk-CuA"/>
                 <outlet property="datePicker" destination="DeJ-zZ-fUs" id="ygZ-TO-h0E"/>
             </connections>
-            <point key="canvasLocation" x="211.59420289855075" y="181.80803571428569"/>
+            <point key="canvasLocation" x="261.59420289855075" y="166.40625"/>
         </tableViewCell>
     </objects>
 </document>

--- a/QuestionApp/LabelAndTextViewTableViewCell.swift
+++ b/QuestionApp/LabelAndTextViewTableViewCell.swift
@@ -1,0 +1,24 @@
+//
+//  LabelAndTextViewTableViewCell.swift
+//  QuestionApp
+//
+//  Created by AYANO HARA on 2020/09/14.
+//  Copyright © 2020 AYANO HARA. All rights reserved.
+//
+
+import UIKit
+
+class LabelAndTextViewTableViewCell: UITableViewCell {
+    
+    @IBOutlet weak var categoryLabel: UILabel!
+    @IBOutlet weak var categoryTextView: UITextView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.selectionStyle = .none
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+}

--- a/QuestionApp/LabelAndTextViewTableViewCell.xib
+++ b/QuestionApp/LabelAndTextViewTableViewCell.xib
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="154" id="KGk-i7-Jjw" customClass="LabelAndTextViewTableViewCell" customModule="QuestionApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="451" height="154"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="451" height="154"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ajk-FH-g9X">
+                        <rect key="frame" x="28" y="10" width="210" height="21"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="TextView" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="xM9-hU-Fm4">
+                        <rect key="frame" x="28" y="39" width="413" height="106"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                    </textView>
+                </subviews>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="categoryLabel" destination="ajk-FH-g9X" id="pVf-9u-cyY"/>
+                <outlet property="categoryTextView" destination="xM9-hU-Fm4" id="Fe2-Y2-v2D"/>
+            </connections>
+            <point key="canvasLocation" x="247.10144927536234" y="176.78571428571428"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/QuestionApp/LabelAndTextViewTableViewCell.xib
+++ b/QuestionApp/LabelAndTextViewTableViewCell.xib
@@ -16,22 +16,28 @@
                 <rect key="frame" x="0.0" y="0.0" width="451" height="154"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ajk-FH-g9X">
-                        <rect key="frame" x="28" y="10" width="210" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ajk-FH-g9X">
+                        <rect key="frame" x="8" y="8" width="42" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="TextView" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="xM9-hU-Fm4">
-                        <rect key="frame" x="28" y="39" width="413" height="106"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="TextView" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="xM9-hU-Fm4">
+                        <rect key="frame" x="8" y="33" width="435" height="109"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                     </textView>
                 </subviews>
+                <constraints>
+                    <constraint firstItem="ajk-FH-g9X" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="2sA-pI-XNE"/>
+                    <constraint firstItem="xM9-hU-Fm4" firstAttribute="top" secondItem="ajk-FH-g9X" secondAttribute="bottom" constant="4" id="HhY-Tc-Rpm"/>
+                    <constraint firstAttribute="trailing" secondItem="xM9-hU-Fm4" secondAttribute="trailing" constant="8" id="bFV-Z6-YFA"/>
+                    <constraint firstItem="ajk-FH-g9X" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="guC-fH-ekR"/>
+                    <constraint firstItem="xM9-hU-Fm4" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="jZ5-me-bLt"/>
+                    <constraint firstAttribute="bottom" secondItem="xM9-hU-Fm4" secondAttribute="bottom" constant="12" id="pu2-68-WHd"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>

--- a/QuestionApp/View/Base.lproj/Main.storyboard
+++ b/QuestionApp/View/Base.lproj/Main.storyboard
@@ -70,7 +70,13 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="NQp-wY-ruh"/>
                     </view>
-                    <navigationItem key="navigationItem" title="質問内容" id="a5b-vM-gYk"/>
+                    <navigationItem key="navigationItem" title="質問内容" id="a5b-vM-gYk">
+                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="Ule-Nv-CX2">
+                            <connections>
+                                <segue destination="XVx-yr-yoH" kind="presentation" modalPresentationStyle="fullScreen" id="vsA-Bi-gdO"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="GcS-Cr-Uxy" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -83,13 +89,30 @@
                     <view key="view" contentMode="scaleToFill" id="FJu-MU-g9h">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fIm-uH-NZO">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="Qeg-G1-JvZ">
+                                        <rect key="frame" x="0.0" y="28" width="414" height="98"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Qeg-G1-JvZ" id="b52-U3-JI5">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="98"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="rSC-FH-kFx"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OxR-Sz-PIk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2494" y="408"/>
+            <point key="canvasLocation" x="2492.753623188406" y="407.8125"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="pzo-xP-mde">

--- a/QuestionApp/View/Base.lproj/Main.storyboard
+++ b/QuestionApp/View/Base.lproj/Main.storyboard
@@ -76,6 +76,21 @@
             </objects>
             <point key="canvasLocation" x="1679.7101449275362" y="408.48214285714283"/>
         </scene>
+        <!--Register Questions View Controller-->
+        <scene sceneID="dGO-D1-KEF">
+            <objects>
+                <viewController id="XVx-yr-yoH" customClass="RegisterQuestionsViewController" customModule="QuestionApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="FJu-MU-g9h">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="rSC-FH-kFx"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="OxR-Sz-PIk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2494" y="408"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="pzo-xP-mde">
             <objects>

--- a/QuestionApp/View/Base.lproj/Main.storyboard
+++ b/QuestionApp/View/Base.lproj/Main.storyboard
@@ -90,9 +90,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fIm-uH-NZO">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fIm-uH-NZO">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="Qeg-G1-JvZ">
@@ -105,15 +104,23 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9qg-1S-aO1">
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9qg-1S-aO1">
                                 <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem title="質問を新規登録" id="U23-3o-o00"/>
                                 </items>
                             </navigationBar>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="9qg-1S-aO1" firstAttribute="top" secondItem="rSC-FH-kFx" secondAttribute="top" id="0vC-DN-1qD"/>
+                            <constraint firstItem="fIm-uH-NZO" firstAttribute="trailing" secondItem="rSC-FH-kFx" secondAttribute="trailing" id="3h9-dA-sUY"/>
+                            <constraint firstItem="fIm-uH-NZO" firstAttribute="bottom" secondItem="rSC-FH-kFx" secondAttribute="bottom" id="3sp-zV-2QO"/>
+                            <constraint firstItem="fIm-uH-NZO" firstAttribute="top" secondItem="9qg-1S-aO1" secondAttribute="bottom" id="XBd-7q-nVX"/>
+                            <constraint firstItem="9qg-1S-aO1" firstAttribute="leading" secondItem="rSC-FH-kFx" secondAttribute="leading" id="gBg-vZ-tXk"/>
+                            <constraint firstItem="fIm-uH-NZO" firstAttribute="leading" secondItem="rSC-FH-kFx" secondAttribute="leading" id="k20-Jr-dKY"/>
+                            <constraint firstItem="9qg-1S-aO1" firstAttribute="trailing" secondItem="rSC-FH-kFx" secondAttribute="trailing" id="ykt-xy-kbR"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="rSC-FH-kFx"/>
                     </view>
                     <connections>

--- a/QuestionApp/View/Base.lproj/Main.storyboard
+++ b/QuestionApp/View/Base.lproj/Main.storyboard
@@ -91,7 +91,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fIm-uH-NZO">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <prototypes>
@@ -105,11 +105,19 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9qg-1S-aO1">
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <items>
+                                    <navigationItem title="質問を新規登録" id="U23-3o-o00"/>
+                                </items>
+                            </navigationBar>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="rSC-FH-kFx"/>
                     </view>
                     <connections>
+                        <outlet property="navigationBar" destination="9qg-1S-aO1" id="Ftx-7b-SKa"/>
                         <outlet property="tableView" destination="fIm-uH-NZO" id="ise-x8-5gd"/>
                     </connections>
                 </viewController>

--- a/QuestionApp/View/Base.lproj/Main.storyboard
+++ b/QuestionApp/View/Base.lproj/Main.storyboard
@@ -90,7 +90,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fIm-uH-NZO">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="fIm-uH-NZO">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>

--- a/QuestionApp/View/Base.lproj/Main.storyboard
+++ b/QuestionApp/View/Base.lproj/Main.storyboard
@@ -109,6 +109,9 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="rSC-FH-kFx"/>
                     </view>
+                    <connections>
+                        <outlet property="tableView" destination="fIm-uH-NZO" id="ise-x8-5gd"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OxR-Sz-PIk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>


### PR DESCRIPTION
**clone コマンド**
git clone feature/add-UI-RegisterQuestionsVC -b feature/add-UI-RegisterQuestionsVC

**Trello**
質問内容画面のUI作成

**概要**
・質問内容登録画面のUIを作成
・カスタムセルを作成(TextViewとDatePicker)

**レビューで見て欲しいポイント**
・画面遷移するかどうか
・オートレイアウトは正確か
・UIに追加したほうが良いものはあるか

**実機build/期待通りの挙動をするか**
OK

**追加したチケット**
質問内容登録画面のUI修正 (新規登録画面のUI作成をマージした後)

**補足**
新規登録画面のUI作成ブランチで作成したカスタムセルを使いたいため、新規登録画面のUI作成ブランチをマージした後に修正が必要。別途チケット切ってあります。
現在はTextViewを使っているが、必要ない可能性あり。
