### PR TITLE
項目数と順序を変更

### DIFF
--- a/QuestionApp/Controller/RegisterQuestionsViewController.swift
+++ b/QuestionApp/Controller/RegisterQuestionsViewController.swift
@@ -32,12 +32,14 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, 
         case person = "質問する相手"
         case date = "会う予定の日"
         case question = "質問内容"
+        case nextAction = "次のアクション"
         
         var QuestionPlaceHolderList: String {
             switch self {
             case .person: return "例)田中 太郎"
             case .date: return "例)2021/01/01"
             case .question: return "例)食事制限をしないダイエット方法"
+            case . nextAction: return "例)教えてもらったダイエット方法を１ヶ月続ける"
             }
         }
     }

--- a/QuestionApp/Controller/RegisterQuestionsViewController.swift
+++ b/QuestionApp/Controller/RegisterQuestionsViewController.swift
@@ -12,8 +12,8 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, 
     
     //登録したい内容の値を保持
     var personString: String?
-    var contentsString: String?
     var dateString: String?
+    var contentsString: String?
     
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var navigationBar: UINavigationBar!
@@ -30,14 +30,14 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, 
     
     enum QuestionList: String, CaseIterable{
         case person = "質問する相手"
-        case question = "質問内容"
         case date = "会う予定の日"
+        case question = "質問内容"
         
         var QuestionPlaceHolderList: String {
             switch self {
             case .person: return "例)田中 太郎"
-            case .question: return "例)食事制限をしないダイエット方法"
             case .date: return "例)2021/01/01"
+            case .question: return "例)食事制限をしないダイエット方法"
             }
         }
     }
@@ -47,12 +47,12 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, 
         tableView.dataSource = self
         navigationBar.delegate = self
         let categoryNib = UINib(nibName: "CategoryLabelAndTFTableViewCell", bundle: nil)
-        let questionTextViewNib = UINib(nibName: "LabelAndTextViewTableViewCell", bundle: nil)
         let datePickerNib = UINib(nibName: "LabelAndDatePickerTableViewCell", bundle: nil)
+        let questionTextViewNib = UINib(nibName: "LabelAndTextViewTableViewCell", bundle: nil)
         let commonActionButtonNib = UINib(nibName: "CommonActionButtonTableViewCell", bundle: nil)
         tableView.register(categoryNib, forCellReuseIdentifier: "CategoryCell")
-        tableView.register(questionTextViewNib, forCellReuseIdentifier: "LabelAndTextViewCell")
         tableView.register(datePickerNib, forCellReuseIdentifier: "LabelAndDatePickerCell")
+        tableView.register(questionTextViewNib, forCellReuseIdentifier: "LabelAndTextViewCell")
         tableView.register(commonActionButtonNib, forCellReuseIdentifier: "CommonActionButtonCell")
     }
     
@@ -62,13 +62,13 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, 
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let categoryCell = tableView.dequeueReusableCell(withIdentifier: "CategoryCell", for: indexPath) as! CategoryLabelAndTFTableViewCell
-        let questionTextViewCell = tableView.dequeueReusableCell(withIdentifier: "LabelAndTextViewCell", for: indexPath) as! LabelAndTextViewTableViewCell
         let datePickerCell = tableView.dequeueReusableCell(withIdentifier: "LabelAndDatePickerCell", for: indexPath) as! LabelAndDatePickerTableViewCell
+        let questionTextViewCell = tableView.dequeueReusableCell(withIdentifier: "LabelAndTextViewCell", for: indexPath) as! LabelAndTextViewTableViewCell
         let commonActionButtonCell = tableView.dequeueReusableCell(withIdentifier: "CommonActionButtonCell", for: indexPath) as! CommonActionButtonTableViewCell
         
         categoryCell.delegate = self
-        questionTextViewCell.delegate = self
         datePickerCell.delegate = self
+        questionTextViewCell.delegate = self
         
         switch indexPath.row {
         case 0:
@@ -77,14 +77,14 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, 
             categoryCell.indexNumber = indexPath.row
             return categoryCell
         case 1:
+            datePickerCell.categoryLabel.text = QuestionList.date.rawValue
+            datePickerCell.indexNumber = indexPath.row
+            return datePickerCell
+        case 2:
             questionTextViewCell.categoryLabel.text = QuestionList.question.rawValue
             questionTextViewCell.categoryTextView.text = "" //TextViewという文字が入るため
             questionTextViewCell.indexNumber = indexPath.row
             return questionTextViewCell
-        case 2:
-            datePickerCell.categoryLabel.text = QuestionList.date.rawValue
-            datePickerCell.indexNumber = indexPath.row
-            return datePickerCell
         case 3:
             commonActionButtonCell.delegate = self
             commonActionButtonCell.leftSideButton.setTitle("キャンセル", for: .normal)
@@ -108,19 +108,19 @@ extension RegisterQuestionsViewController: CommonActionButtonTableViewCellDelega
 }
 
 //各セルで入力された値を取得する
-extension RegisterQuestionsViewController: CategoryLabelAndTFTableViewCellDelegate, LabelAndTextViewTableViewCellDelegate, LabelAndDatePickerTableViewCellDelegate {
-    func fetchQuestionsText(textField: UITextField?, textView: UITextView?, date: String?, indexNumber: Int) {
+extension RegisterQuestionsViewController: CategoryLabelAndTFTableViewCellDelegate, LabelAndDatePickerTableViewCellDelegate, LabelAndTextViewTableViewCellDelegate {
+    func fetchQuestionsText(textField: UITextField?, date: String?, textView: UITextView?, indexNumber: Int) {
         enum CategoryNameText: Int {
             case person
-            case contents
             case date
+            case contents
         }
         
         let questionsText = CategoryNameText(rawValue: indexNumber)
         switch questionsText {
         case .person: personString = textField?.text
-        case .contents: contentsString = textView?.text
         case .date: dateString = date
+        case .contents: contentsString = textView?.text
         case .none: break
         }
     }
@@ -132,7 +132,7 @@ extension RegisterQuestionsViewController {
         let alert = UIAlertController(title: "入力した内容を登録しますか？", message: "", preferredStyle: .alert)
         let saveAction = UIAlertAction(title: "登録する", style: .default) { _ in
             let crudModel = QuestionDataCrudModel()
-            crudModel.createQuestionsData(person: self.personString ?? "???", contents: self.contentsString ?? "???", date: self.dateString ?? "???")
+            crudModel.createQuestionsData(person: self.personString ?? "???", date: self.dateString ?? "???", contents: self.contentsString ?? "???")
             self.dismiss(animated: true, completion: nil)
         }
         let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: nil)

--- a/QuestionApp/Controller/RegisterQuestionsViewController.swift
+++ b/QuestionApp/Controller/RegisterQuestionsViewController.swift
@@ -14,7 +14,6 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, 
     var personString: String?
     var contentsString: String?
     var dateString: String?
-    var nextActionString: String?
     
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var navigationBar: UINavigationBar!
@@ -33,14 +32,12 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, 
         case person = "質問する相手"
         case question = "質問内容"
         case date = "会う予定の日"
-        case nextAction = "次のアクション"
         
         var QuestionPlaceHolderList: String {
             switch self {
             case .person: return "例)田中 太郎"
             case .question: return "例)食事制限をしないダイエット方法"
             case .date: return "例)2021/01/01"
-            case .nextAction: return "例)教えてもらったダイエット方法を１ヶ月続ける"
             }
         }
     }
@@ -89,11 +86,6 @@ class RegisterQuestionsViewController: UIViewController, UITableViewDataSource, 
             datePickerCell.indexNumber = indexPath.row
             return datePickerCell
         case 3:
-            categoryCell.categoryLabel.text = QuestionList.nextAction.rawValue
-            categoryCell.categoryTextField.placeholder = QuestionList.nextAction.QuestionPlaceHolderList
-            categoryCell.indexNumber = indexPath.row
-            return categoryCell 
-        case 4:
             commonActionButtonCell.delegate = self
             commonActionButtonCell.leftSideButton.setTitle("キャンセル", for: .normal)
             commonActionButtonCell.rightSideButton.setTitle("質問を登録", for: .normal)
@@ -122,7 +114,6 @@ extension RegisterQuestionsViewController: CategoryLabelAndTFTableViewCellDelega
             case person
             case contents
             case date
-            case nextAction
         }
         
         let questionsText = CategoryNameText(rawValue: indexNumber)
@@ -130,7 +121,6 @@ extension RegisterQuestionsViewController: CategoryLabelAndTFTableViewCellDelega
         case .person: personString = textField?.text
         case .contents: contentsString = textView?.text
         case .date: dateString = date
-        case .nextAction: nextActionString = textField?.text
         case .none: break
         }
     }
@@ -142,7 +132,7 @@ extension RegisterQuestionsViewController {
         let alert = UIAlertController(title: "入力した内容を登録しますか？", message: "", preferredStyle: .alert)
         let saveAction = UIAlertAction(title: "登録する", style: .default) { _ in
             let crudModel = QuestionDataCrudModel()
-            crudModel.createQuestionsData(person: self.personString ?? "???", contents: self.contentsString ?? "???", date: self.dateString ?? "???", nextAction: self.nextActionString ?? "???")
+            crudModel.createQuestionsData(person: self.personString ?? "???", contents: self.contentsString ?? "???", date: self.dateString ?? "???")
             self.dismiss(animated: true, completion: nil)
         }
         let cancelAction = UIAlertAction(title: "キャンセル", style: .cancel, handler: nil)

--- a/QuestionApp/Model/QuestionDataCrudModel.swift
+++ b/QuestionApp/Model/QuestionDataCrudModel.swift
@@ -13,8 +13,8 @@ class QuestionDataCrudModel {
     
     let ref = Database.database().reference()
     
-    func createQuestionsData(person: String, contents: String, date: String) {
-        let createDataDict = ["質問相手": person, "質問内容": contents, "日付": date]
+    func createQuestionsData(person: String, date: String, contents: String) {
+        let createDataDict = ["質問相手": person, "日付": date, "質問内容": contents]
         ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createDataDict)
     }
 }

--- a/QuestionApp/Model/QuestionDataCrudModel.swift
+++ b/QuestionApp/Model/QuestionDataCrudModel.swift
@@ -13,8 +13,8 @@ class QuestionDataCrudModel {
     
     let ref = Database.database().reference()
     
-    func createQuestionsData(person: String, contents: String, date: String, nextAction: String) {
-        let createDataDict = ["質問相手": person, "質問内容": contents, "日付": date, "次のアクション": nextAction]
+    func createQuestionsData(person: String, contents: String, date: String) {
+        let createDataDict = ["質問相手": person, "質問内容": contents, "日付": date]
         ref.child(Auth.auth().currentUser!.uid).childByAutoId().setValue(createDataDict)
     }
 }

--- a/QuestionApp/View/Cell/CategoryLabelAndTFTableViewCell.swift
+++ b/QuestionApp/View/Cell/CategoryLabelAndTFTableViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol CategoryLabelAndTFTableViewCellDelegate {
     //登録画面でTFに入力した値を取得
-    func fetchQuestionsText(textField: UITextField?, textView: UITextView?, date: String?, indexNumber: Int)
+    func fetchQuestionsText(textField: UITextField?, date: String?, textView: UITextView?, indexNumber: Int)
 }
 
 class CategoryLabelAndTFTableViewCell: UITableViewCell, UITextFieldDelegate {
@@ -38,6 +38,6 @@ class CategoryLabelAndTFTableViewCell: UITableViewCell, UITextFieldDelegate {
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        delegate?.fetchQuestionsText(textField: textField, textView: nil, date: nil, indexNumber: indexNumber!)
+        delegate?.fetchQuestionsText(textField: textField, date: nil, textView: nil, indexNumber: indexNumber!)
     }
 }

--- a/QuestionApp/View/Cell/LabelAndDatePickerTableViewCell.swift
+++ b/QuestionApp/View/Cell/LabelAndDatePickerTableViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol LabelAndDatePickerTableViewCellDelegate {
     //登録画面datePickerで選択した値を取得
-    func fetchQuestionsText(textField: UITextField?, textView: UITextView?, date: String?, indexNumber: Int)
+    func fetchQuestionsText(textField: UITextField?, date: String?, textView: UITextView?, indexNumber: Int)
 }
 
 class LabelAndDatePickerTableViewCell: UITableViewCell {
@@ -36,6 +36,6 @@ class LabelAndDatePickerTableViewCell: UITableViewCell {
         formatter.locale = Locale(identifier: "ja_JP")
         formatter.dateFormat = "yyyy年MM月dd日"
         dateString = formatter.string(from: datePicker.date)
-        delegate?.fetchQuestionsText(textField: nil, textView: nil, date: dateString, indexNumber: indexNumber!)
+        delegate?.fetchQuestionsText(textField: nil, date: dateString, textView: nil, indexNumber: indexNumber!)
     }
 }

--- a/QuestionApp/View/Cell/LabelAndTextViewTableViewCell.swift
+++ b/QuestionApp/View/Cell/LabelAndTextViewTableViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 protocol LabelAndTextViewTableViewCellDelegate {
     //登録画面でTVに入力した値を取得
-    func fetchQuestionsText(textField: UITextField?, textView: UITextView?, date: String?, indexNumber: Int)
+    func fetchQuestionsText(textField: UITextField?, date: String?, textView: UITextView?, indexNumber: Int)
 }
 
 class LabelAndTextViewTableViewCell: UITableViewCell, UITextViewDelegate {
@@ -33,7 +33,7 @@ class LabelAndTextViewTableViewCell: UITableViewCell, UITextViewDelegate {
     }
     
     func textViewDidEndEditing(_ textView: UITextView) {
-        delegate?.fetchQuestionsText(textField: nil, textView: textView, date: nil, indexNumber: indexNumber!)
+        delegate?.fetchQuestionsText(textField: nil, date: nil, textView: textView, indexNumber: indexNumber!)
     }
 }
 


### PR DESCRIPTION
## clone コマンド
git clone git@github.com:HaraFuchi/QuestionApp.git -b feature/fix-UI-RegisterVC

## Trello
質問登録画面の項目数と順番を修正

## 概要
・質問登録画面の項目数と順番を変更
【従来】
1. 相手
2. 内容
3. 日付
4. 次のアクション

【修正後】
1. 相手
2. 日付
3. 内容

## 変更後のUI
＊iPhone11
![Simulator Screen Shot - iPhone 11 - 2020-10-22 at 17 38 16](https://user-images.githubusercontent.com/65425673/96846912-7f15a000-148d-11eb-9343-d5c1f7630c1a.png)

＊iPhoneSE(2nd)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-10-22 at 17 34 57](https://user-images.githubusercontent.com/65425673/96846929-83da5400-148d-11eb-96c3-6d45626ac0aa.png)

## レビューで見て欲しいポイント
・変更内容は適切か
・他に改善点はないか

## 参考URL

## 実機build/期待通りの挙動をするか
OK

## 追加したチケット
ホーム画面の"次のアクション"のラベルも削除

